### PR TITLE
Specify nom crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Nikolaj Schlej <schlej@live.de>"]
 
 [dependencies]
 flate2 = "0.2"
-nom = { git = "https://github.com/Geal/nom" }
+nom = "4.2"


### PR DESCRIPTION
The master branch of nom contains breaking changes which prevent
compilation. Use the latest stable release instead.